### PR TITLE
updated swkrm's URL to point to softwerkskammer.org

### DIFF
--- a/usergroup/swkrm.xml
+++ b/usergroup/swkrm.xml
@@ -9,7 +9,7 @@
         Wir treffen uns durchschnittlich einmal im Monat wobei das stets wechselnde Rahmenthema für ein Treffen beim
         vorherigen Treffen festgelegt werden.
     </description>
-    <url>http://www.softwerkskammer.de/wiki/SoftwerkskammerFfm</url>
+    <url>http://softwerkskammer.org/groups/rheinmain</url>
     <tags>
         <tag>Software Craftsmanship</tag>
         <tag>Clean Code</tag>


### PR DESCRIPTION
Die "Gruppen-URL" hat noch zum alten softwerkskammer.de Wiki gezeigt. 
