### PR TITLE
Datum fuer Freifunk Darmstadt korrigiert

### DIFF
--- a/usergroup/ffda.xml
+++ b/usergroup/ffda.xml
@@ -28,7 +28,7 @@
         <!-- ical> https://www.google.com/calendar/ical/q408a75de70rb2ebqka3i18nc0%40group.calendar.google.com/public/basic.ics
             </ical -->
         <meeting>
-            <time>2014-02-11T19:30:00+01:00</time>
+            <time>2014-02-13T19:30:00+01:00</time>
             <name>Erstes Treffen von Freifunk Darmstadt</name>
             <location>
                 <name>Trollhöhle Chaos Darmstadt</name>


### PR DESCRIPTION
Danke fürs schnelle mergen, hatte leider das falsche Datum eingetragen.
