### PR TITLE
Update pyugrm.xml

### DIFF
--- a/usergroup/pyugrm.xml
+++ b/usergroup/pyugrm.xml
@@ -8,7 +8,7 @@
         Rhein-Main-Gebiet.
         Ruby-Entwickler sind ebenfalls herzlich eingeladen.
     </description>
-    <url>http://wiki.python-forum.de/PyUGRM</url>
+    <url>http://pyugrm.de/</url>
     <tags>
         <tag>Python</tag>
         <tag>Ruby</tag>
@@ -48,7 +48,7 @@
         <meeting>
             <time>2014-05-15T19:30:00+02:00</time>
             <name>13. Treffen der PyUGRM</name>
-            <url>http://wiki.python-forum.de/PyUGRM/Treffen20140515</url>
+            <url>http://pyugrm.de/stories/termine-der-python-user-group-rhein-main/#mai-2014</url>
         </meeting>
         <meeting>
             <time>2014-03-19T19:30:00+01:00</time>


### PR DESCRIPTION
Das Wiki des Python-Forums ist offenbar gestorben und seit ein paar Tagen nicht erreichbar. Wir haben jetzt eine eigene Webseite unter http://pyugrm.de/ eingerichtet und migrieren darauf. Deshalb müssen die Links angepasst werden. Danke! :-)
